### PR TITLE
This puts Chaintree in the nav.  Next PR will enable mermaid diagrams.

### DIFF
--- a/docs/chaintree.md
+++ b/docs/chaintree.md
@@ -1,4 +1,9 @@
-
+---
+layout: default
+title: What is a ChainTree
+parent: Platform Documentation
+nav_order: 3
+---
 # What's a ChainTree?
 
 ## Overview
@@ -23,14 +28,14 @@ end
 subgraph Chain
 Chain -- Latest --> b3["Block 3"]
 Chain -- Genesis --> gen
-b2["Block 2"] --> b3 
+b2["Block 2"] --> b3
 gen["Genesis"] --> b2
 end
 ```
 
-A ChainTree is [content addressable](https://en.wikipedia.org/wiki/Content-addressable_storage), meaning that a single hash of the root uniquely represents the entire data structure. 
+A ChainTree is [content addressable](https://en.wikipedia.org/wiki/Content-addressable_storage), meaning that a single hash of the root uniquely represents the entire data structure.
 
-[Tupelo's whitepaper](https://docs.quorumcontrol.com/docs/whitepaper.html) explains how ChainTrees use [IPLD](https://ipld.io/) internally. 
+[Tupelo's whitepaper](https://docs.quorumcontrol.com/docs/whitepaper.html) explains how ChainTrees use [IPLD](https://ipld.io/) internally.
 
 > [...] at a high level, IPLD specifies how to link data structures using a content addressable system (hashing). Conceptually similar to JSON, Tupelo uses CBOR (Compact Binary Object Representation) to model the data inside a ChainTree. CBOR specifies a canonical way to create a binary given key/value pairs. An object can link to another object by specifying a CID as a value within one if its key/value pairs. A CID represents a hash of the object linked TO. In this way, a single tip (hash of the root object) can be used to verify that all children of the object have not been tampered with.
 
@@ -93,7 +98,7 @@ And block would look like this:
         "path": "/my/subtree/foo",
 	"value": "bar"
       }   
-    }] 
+    }]
   }
 }
 ```


### PR DESCRIPTION
I need to both integrate this into the Nav (right now moving it under documentation but plan to create an FAQ or Concepts section when we have more entries) and fix the mermaid diagrams.
Note Mermaid is broken but wanted to do that in separate PR and get this Nav fixed in master ASAP.