### PR TITLE
Remove check for whether nav item should be "open" so all nav items a…

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,7 +4,7 @@
     {% for node in pages_list %}
       {% unless node.nav_exclude %}
         {% if node.parent == nil %}
-          <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+          <li class="navigation-list-item active">
             {% if page.parent == node.title or page.grand_parent == node.title %}
               {% assign first_level_url = node.url | absolute_url %}
             {% endif %}


### PR DESCRIPTION
![screen shot 2019-03-04 at 4 23 41 pm](https://user-images.githubusercontent.com/12204/53763913-ea19f980-3e99-11e9-989a-b899a9c780a1.png)

This is what the nav looks like after this change.  Basically all items are open.
The bolded black one is the "active" one and that appears to still work correctly.