### PR TITLE
Fixing client version number in the notebook tutorial.

### DIFF
--- a/tutorials/notebook.md
+++ b/tutorials/notebook.md
@@ -53,7 +53,7 @@ In file `notebook/package.json`:
   "name": "notebook",
   ...
   "dependencies": {
-      "tupelo-client": "^0.0.4"
+      "tupelo-client": "^0.1.0"
   },
 }
 ```

--- a/tutorials/notebook.md
+++ b/tutorials/notebook.md
@@ -53,7 +53,7 @@ In file `notebook/package.json`:
   "name": "notebook",
   ...
   "dependencies": {
-      "tupelo-client": "^0.0.2-alpha1"
+      "tupelo-client": "^0.0.4"
   },
 }
 ```


### PR DESCRIPTION
I missed one reference to the client version number in the notebook tutorial