### PR TITLE
s/coin/token/g

### DIFF
--- a/docs/chaintree.md
+++ b/docs/chaintree.md
@@ -23,7 +23,7 @@ subgraph Tree
   Arb --> Anything
   Arb --> uw["user wants"]
   Tree --> _tupelo
-  _tupelo --> Coins
+  _tupelo --> Tokens
   _tupelo --> Ownership
   Ownership --> PublicKeys
 end

--- a/docs/litepaper.md
+++ b/docs/litepaper.md
@@ -20,7 +20,7 @@ nav_order: 1
 Tupelo is a new Distributed Ledger Technology (DLT) project that is fundamentally different. Rather than a single blockchain, Tupelo maintains a separate history for every object. The history is kept in a new data structure called a Chain Tree. This foundational change is ideal for a variety of applications that concern assets (both physical and digital) and supports crypto currency applications.
 
 ## Understanding Tupelo
-Most DLT systems are built around a detailed accounting of who has how many fungible (interchangeable) coins. Foundationally, Tupelo is built to model more complex, unique, real-world or digital things. Every object in Tupelo innately has one or more owners, a variety of attributes, and a unique history.
+Most DLT systems are built around a detailed accounting of who has how many fungible (interchangeable) tokens. Foundationally, Tupelo is built to model more complex, unique, real-world or digital things. Every object in Tupelo innately has one or more owners, a variety of attributes, and a unique history.
 
 For example, consider a car, a house, a digital collectible, a person’s identity, or a batch of coffee moving through a supply chain. Each of these objects has many unique instantiations with different features. Their attributes may change over time but they all represent a singular unique entity, have specified owners at any given time, and have a history that persists.
 
@@ -81,14 +81,14 @@ One of the core strengths of Tupelo is the simplicity of the interface (API) pro
 For illustration purposes the current API includes the following high level requests:
   * SET_DATA
   * SET_OWNERSHIP
-  * ESTABLISH_COIN
-  * MINT_COIN
-  * SEND_COIN
-  * RECEIVE_COIN
+  * ESTABLISH_TOKEN
+  * MINT_TOKEN
+  * SEND_TOKEN
+  * RECEIVE_TOKEN
 
-Tupelo is not focused on building a purely financial system but rather a utilitarian one. That however does not mean that it cannot mint or transfer coins. Other DLT systems have central universal storage and Chain Trees are distributed, but that does not mean Tupelo is in any way inferior at preventing double spends. Double spends occur when a single user trades their tokens away more than once, which is the core challenge of managing coins.
+Tupelo is not focused on building a purely financial system but rather a utilitarian one. That however does not mean that it cannot mint or transfer tokens. Other DLT systems have central universal storage and Chain Trees are distributed, but that does not mean Tupelo is in any way inferior at preventing double spends. Double spends occur when a single user trades their tokens away more than once, which is the core challenge of managing tokens.
 
-A Chain Tree owner can never double spend because the SEND_COIN transaction will not be approved unless there is enough of a balance. The owner cannot fork their Chain Tree to add fraudulent spends, and a receiver cannot add more RECEIVE_COIN blocks without having valid (and unique) transaction ids signed by the Notary Group. Request the Tupelo Whitepaper for more details on how Tupelo maintains coin integrity.
+A Chain Tree owner can never double spend because the SEND_TOKEN transaction will not be approved unless there is enough of a balance. The owner cannot fork their Chain Tree to add fraudulent spends, and a receiver cannot add more RECEIVE_TOKEN blocks without having valid (and unique) transaction ids signed by the Notary Group. Request the Tupelo Whitepaper for more details on how Tupelo maintains token integrity.
 
 Tupelo allows for unlimited currencies without smart contracts. It is important to note that these capabilities are particularly valuable for applications that involve fractional ownership or other shared ownership models.
 
@@ -99,7 +99,7 @@ Tupelo’s unique features make it good for modeling things, be they physical or
 
 ### Real world assets
 
-Real world assets such as real estate or cars are an excellent fit for Tupelo. Application developers can easily model these assets with the flexible data structure that automatically tracks their history. One or more people own the structures themselves, and those people can grant non-owners limited read or write capability. These features are all fundamentally derived from the Chain Tree itself directly modeling their existence not as a coin, but as a singular owned data structure.
+Real world assets such as real estate or cars are an excellent fit for Tupelo. Application developers can easily model these assets with the flexible data structure that automatically tracks their history. One or more people own the structures themselves, and those people can grant non-owners limited read or write capability. These features are all fundamentally derived from the Chain Tree itself directly modeling their existence not as a token, but as a singular owned data structure.
 
 ### Digital assets
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -83,10 +83,10 @@ Only the owner(s) of a Chain Tree may create new transactions on a Chain Tree. T
 Transactions are arbitrary mutations of state. The client and Notary Group must agree on the process of mutating state through named transactions. The initial release will include the following transactions\:
   * `SET_DATA`
   * `SET_OWNERSHIP`
-  * `ESTABLISH_COIN`
-  * `MINT_COIN`
-  * `SEND_COIN`
-  * `RECEIVE_COIN`
+  * `ESTABLISH_TOKEN`
+  * `MINT_TOKEN`
+  * `SEND_TOKEN`
+  * `RECEIVE_TOKEN`
 
 Later, we will discuss how user-defined transactions can be used to expand the system in a manner similar to smart-contracts on other DLT systems.
 
@@ -94,35 +94,35 @@ Later, we will discuss how user-defined transactions can be used to expand the s
 
 Initial implementations include a protocol to transfer quantities of a token. Conceptually this is the same as any other cryptocurrency token such as Ethereum or Bitcoin. Chain Trees and Notary Groups accomplish double-spend protection on top of the existing layer of trust described above and do not need a global ledger. This system allows for unlimited currencies on the same notarized system without the need for smart contracts.
 
-Currency exchange introduces 4 transaction types: `ESTABLISH_COIN`, `MINT_COIN`, `SEND_COIN`, `RECEIVE_COIN`. The Chain Tree structure is modeled as in Figure 3. This layout allows for efficient double-spend checking by sending in all the receives. However, a future improvement to the protocol will use balance check pointing and a cryptographic accumulator (or zk-snark) to prove non-existence of the receive.
+Currency exchange introduces 4 transaction types: `ESTABLISH_TOKEN`, `MINT_TOKEN`, `SEND_TOKEN`, `RECEIVE_TOKEN`. The Chain Tree structure is modeled as in Figure 3. This layout allows for efficient double-spend checking by sending in all the receives. However, a future improvement to the protocol will use balance check pointing and a cryptographic accumulator (or zk-snark) to prove non-existence of the receive.
 
 <img src="../assets/images/actor-dag.png">
 ##### Figure 3 - Cryptocurrency branch of a Chain Tree
 --
 
 ```
-ESTABLISH_COIN
-message EstablishCoinTransaction {
+ESTABLISH_TOKEN
+message EstablishTokenTransaction {
     string name = 1;
     map<string>MonetaryPolicy maximum = 2;
 }
 ```
-Any actor may create one or more of their own coin types. A coin must be established before any coins can be minted, sent or received by any party. Monetary policy is optional but is intended for qualifiers such as hard caps on the number of coins to be issued.  These can not be altered once a coin has been established.  Additional monetary policy options and limiters will be added as the protocol matures.
+Any actor may create one or more of their own token types. A token must be established before any tokens can be minted, sent or received by any party. Monetary policy is optional but is intended for qualifiers such as hard caps on the number of tokens to be issued.  These can not be altered once a token has been established.  Additional monetary policy options and limiters will be added as the protocol matures.
 
 ```
-MINT_COIN
-message MintCoinTransaction {
+MINT_TOKEN
+message MintTokenTransaction {
     string name = 1;
     uint64 amount = 2;
     bytes memo = 3;
 }
 ```
 
-Any actor may mint their own coins once they have been established within that chaintree via an `ESTABLISH_COIN` transaction. They do so by creating a MINT transaction on their Chain Tree. In order for a `MINT_COIN` transaction to be valid, the name of the currency must be prefaced by their Chain Tree’s DID. An example cryptocurrency might be named: `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700:cat_coin` where `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700` is the DID and \'cat_coin\' is the name of the currency. The only potential limitation a Chain Tree owner has on minting more of their own currency is the Monetary Policy set in place when the coin was established.
+Any actor may mint their own tokens once they have been established within that chaintree via an `ESTABLISH_TOKEN` transaction. They do so by creating a MINT transaction on their Chain Tree. In order for a `MINT_TOKEN` transaction to be valid, the name of the currency must be prefaced by their Chain Tree’s DID. An example cryptocurrency might be named: `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700:cat_token` where `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700` is the DID and \'cat_token\' is the name of the currency. The only potential limitation a Chain Tree owner has on minting more of their own currency is the Monetary Policy set in place when the token was established.
 
 ```
-SEND_COIN
-message SendCoinTransaction {
+SEND_TOKEN
+message SendTokenTransaction {
    string id = 1;
    string destination = 2;
    uint64 amount = 3;
@@ -130,25 +130,25 @@ message SendCoinTransaction {
 }
 ```
 
-A `SEND_COIN` transaction is valid if in the state of the Chain Tree there is enough of a balance of “name” coin. The balance is calculated by adding all mints and receives in the Chain Tree and subtracting the Sends. The Chain Tree owner sends the signed tip (and the path through the Chain Tree) that includes the sendcoin. The “balance” is immediately deducted from their Chain Tree in the sense that they cannot add another `SEND_COIN` transaction for more than their balance which includes this transaction. The destination should be the DID of the receiving ChainTree. A `SEND_COIN` transaction is similar to a cashiers check in that the amount is deducted from the senders ChainTree at the time of the `SEND_COIN` transaction. This allows a `RECEIVE_COIN` transaction (see next section) to not depend on any future state of the sender’s ChainTree. The senders’ and receivers’ chain trees are updated independently and therefore there is no multiple Chain Tree transaction needed at the signer level.
+A `SEND_TOKEN` transaction is valid if in the state of the Chain Tree there is enough of a balance of “name” token. The balance is calculated by adding all mints and receives in the Chain Tree and subtracting the Sends. The Chain Tree owner sends the signed tip (and the path through the Chain Tree) that includes the sendtoken. The “balance” is immediately deducted from their Chain Tree in the sense that they cannot add another `SEND_TOKEN` transaction for more than their balance which includes this transaction. The destination should be the DID of the receiving ChainTree. A `SEND_TOKEN` transaction is similar to a cashiers check in that the amount is deducted from the senders ChainTree at the time of the `SEND_TOKEN` transaction. This allows a `RECEIVE_TOKEN` transaction (see next section) to not depend on any future state of the sender’s ChainTree. The senders’ and receivers’ chain trees are updated independently and therefore there is no multiple Chain Tree transaction needed at the signer level.
 
 ```
-RECEIVE_COIN
-message ReceiveCoinTransaction {
-   string send_coin_transaction_id = 1;
+RECEIVE_TOKEN
+message ReceiveTokenTransaction {
+   string send_token_transaction_id = 1;
    bytes tip = 2;
    signature signature = 3;
    map<string>ChainTreeNode leaves = 4;
 }
 ```
 
-A `RECEIVE_COIN` transaction is valid if the Tip including the `SEND_COIN` transaction has been signed by the Notary Group and that Tip includes the transaction, it has a destination that matches this Chain Tree, and it has a `send_coin_transaction_id` that does not appear in the Chain Tree previously (preventing “double receive”).
+A `RECEIVE_TOKEN` transaction is valid if the Tip including the `SEND_TOKEN` transaction has been signed by the Notary Group and that Tip includes the transaction, it has a destination that matches this Chain Tree, and it has a `send_token_transaction_id` that does not appear in the Chain Tree previously (preventing “double receive”).
 
 ### Cryptocurrency Discussion
 
-A Chain Tree owner can never double spend because the `SEND_COIN` transaction will not be approved unless there is enough of a balance. The owner cannot fork their Chain Tree to add fraudulent spends. A receiver cannot add more `RECEIVE_COIN` blocks without having valid (and unique) transaction ids (which are signed by ⅔ of the Notary Group).
+A Chain Tree owner can never double spend because the `SEND_TOKEN` transaction will not be approved unless there is enough of a balance. The owner cannot fork their Chain Tree to add fraudulent spends. A receiver cannot add more `RECEIVE_TOKEN` blocks without having valid (and unique) transaction ids (which are signed by ⅔ of the Notary Group).
 
-`SEND_COIN` can be included in every block as payment to the Signer if an incentification system is necessary for the Notary Group.
+`SEND_TOKEN` can be included in every block as payment to the Signer if an incentification system is necessary for the Notary Group.
 
 ## Notary Groups (consensus algorithm)
 A Notary Group is a registered, bonded set of validator nodes, called Signers, that collectively notarize the tip of every Chain Tree. When an actor adds a block of transactions to their Chain Tree, it sends the block and the new tip hash it creates to the Notary Group along with any state necessary to validate all the transactions in the block. Signers validate these blocks and, if valid, append their digital signatures and forward them to other Signers for more signatures. Once a block receives a supermajority of signatures, the new state, specifically the Merkleized tip of the actor’s Chain Tree, is effectively notarized and will be used as the canonical latest tip for validating the next block on that Chain Tree.
@@ -163,7 +163,7 @@ The Tupelo Consensus Algorithm (TCA) is a leaderless Byzantine Fault Tolerant (B
 
 ### Tuples: The Notary Group’s currency
 
-The main coin of the system is called a Tuple. Tuples are used for rewards, staking and general payments on the Tupelo system. Tuples are minted from the Notary Group itself and are required for creating transactions and participating in the Proof of Stake system.
+The main token of the system is called a Tuple. Tuples are used for rewards, staking and general payments on the Tupelo system. Tuples are minted from the Notary Group itself and are required for creating transactions and participating in the Proof of Stake system.
 
 ### Overview
 
@@ -274,7 +274,7 @@ message DepositStakeTransaction {
 }
 ```
 
-This special transaction functions like a `SEND_COIN` with a fixed destination of the Notary Group Chain Tree. Once the `DEPOSIT_STAKE` transaction has been notarized an active Signer appends a corresponding `ACTIVATE_SIGNER` transaction on the Notary Group Chain Tree.
+This special transaction functions like a `SEND_TOKEN` with a fixed destination of the Notary Group Chain Tree. Once the `DEPOSIT_STAKE` transaction has been notarized an active Signer appends a corresponding `ACTIVATE_SIGNER` transaction on the Notary Group Chain Tree.
 
 ```
 ACTIVATE_SIGNER
@@ -499,7 +499,7 @@ In order to preserve the state of the Notary Group Chain Tree and ensure safety 
 
 #### Processing Withdrawals
 
-Signer deposits remain locked for a period of time ($t$ epochs, on the order of 4 months) after the Signer is inactivated by a `DEACTIVATE_SIGNER` transaction. If the `DEACTIVATE_SIGNER` was posted in epoch $E$ then an when an `EPOCH_END` is written at epoch $E+t$ its `signersRefunded` member functions like a `SEND_COIN` that effectively refunds the balance of all Signers listed. Once that transaction appears on the Notary Group Chain Tree, the Signer can issue a `RECEIVE_COIN` on their own Chain Tree to transfer their balance and allow them to spend it.
+Signer deposits remain locked for a period of time ($t$ epochs, on the order of 4 months) after the Signer is inactivated by a `DEACTIVATE_SIGNER` transaction. If the `DEACTIVATE_SIGNER` was posted in epoch $E$ then an when an `EPOCH_END` is written at epoch $E+t$ its `signersRefunded` member functions like a `SEND_TOKEN` that effectively refunds the balance of all Signers listed. Once that transaction appears on the Notary Group Chain Tree, the Signer can issue a `RECEIVE_TOKEN` on their own Chain Tree to transfer their balance and allow them to spend it.
 
 #### Sending Proposals
 
@@ -524,9 +524,9 @@ To maintain safety across epoch boundaries, specifically to prevent two extensio
 
 In proof of stake blockchains an attacker purchasing enough retired validator keys can rewrite the entire chain's history including FFG checkpoints creating all kinds of double spend opportunities. A user who has been offline for a long period of time can't tell which history is correct. Such users need a trust point, such as a public website containing a list of recent checkpoints, or something hardcoded in the latest version of the software.
 
-In Tupelo such an attacker having purchased 2/3 retired signer keys could create a fork of one or more chain trees if they also had each chain tree owner's signing key. Double spending is not much of concern because a previous spend (`SEND_COIN`) is likely to be referenced in a `RECEIVE_COIN` in some other chain tree that the attacker doesn't have the key to (because they're trying to cheat that chain tree's owner). However, it is possible for an attacker who owns an asset to transfer ownership of that asset multiple times (creating a fork in the asset’s Chain Tree), once with real notarization and once with fake notarization of a past transfer of ownership using acquired keys. For this attack to succeed, the asset Chain Tree must not have been extended recently enough for any Signers to hold a copy of the new notarized tip.
+In Tupelo such an attacker having purchased 2/3 retired signer keys could create a fork of one or more chain trees if they also had each chain tree owner's signing key. Double spending is not much of concern because a previous spend (`SEND_TOKEN`) is likely to be referenced in a `RECEIVE_TOKEN` in some other chain tree that the attacker doesn't have the key to (because they're trying to cheat that chain tree's owner). However, it is possible for an attacker who owns an asset to transfer ownership of that asset multiple times (creating a fork in the asset’s Chain Tree), once with real notarization and once with fake notarization of a past transfer of ownership using acquired keys. For this attack to succeed, the asset Chain Tree must not have been extended recently enough for any Signers to hold a copy of the new notarized tip.
 
-Such attacks can be thwarted by requiring each Chain Tree tip to be extended once every period $T$, where $T$ < the waiting period between `DEACTIVATE_SIGNER` and `SEND_COIN`.
+Such attacks can be thwarted by requiring each Chain Tree tip to be extended once every period $T$, where $T$ < the waiting period between `DEACTIVATE_SIGNER` and `SEND_TOKEN`.
 
 #### Grinding Attacks
 
@@ -560,7 +560,7 @@ Because Chain Trees are independent and not part of a globally ordered history, 
 
 ### Anonymity and Transaction Blinding
 
-Because the Chain Trees are already pseudonymous and there is no global state, the system lends itself to private transactions. Additionally the use of the P2P broadcast network can protect IP addresses, etc from transaction origin. Zero-knowledge proofs could be employed in the `RECEIVE_COIN` and `SEND_COIN` transactions to make for a truly anonymous system.
+Because the Chain Trees are already pseudonymous and there is no global state, the system lends itself to private transactions. Additionally the use of the P2P broadcast network can protect IP addresses, etc from transaction origin. Zero-knowledge proofs could be employed in the `RECEIVE_TOKEN` and `SEND_TOKEN` transactions to make for a truly anonymous system.
 
 ### Sharding
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -138,7 +138,7 @@ message ReceiveTokenTransaction {
    string send_token_transaction_id = 1;
    bytes tip = 2;
    signature signature = 3;
-   map<string>ChainTreeNode leaves = 4;
+   array<ChainTreeNode> leaves = 4;
 }
 ```
 
@@ -285,7 +285,7 @@ message ActivateSignerTransaction {
    string deposit_stake_transaction_id = 4;
    bytes tip = 5;
    signature signature = 6;
-   map<string>ChainTreeNode leaves = 7;
+   array<ChainTreeNode> leaves = 7;
 }
 ```
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -90,14 +90,14 @@ Transactions are arbitrary mutations of state. The client and Notary Group must 
 
 Later, we will discuss how user-defined transactions can be used to expand the system in a manner similar to smart-contracts on other DLT systems.
 
-## Payments Through Cryptocurrency
+## Payments Through Cryptocurrency / Tokens
 
 Initial implementations include a protocol to transfer quantities of a token. Conceptually this is the same as any other cryptocurrency token such as Ethereum or Bitcoin. Chain Trees and Notary Groups accomplish double-spend protection on top of the existing layer of trust described above and do not need a global ledger. This system allows for unlimited currencies on the same notarized system without the need for smart contracts.
 
-Currency exchange introduces 4 transaction types: `ESTABLISH_TOKEN`, `MINT_TOKEN`, `SEND_TOKEN`, `RECEIVE_TOKEN`. The Chain Tree structure is modeled as in Figure 3. This layout allows for efficient double-spend checking by sending in all the receives. However, a future improvement to the protocol will use balance check pointing and a cryptographic accumulator (or zk-snark) to prove non-existence of the receive.
+Token exchange introduces 4 transaction types: `ESTABLISH_TOKEN`, `MINT_TOKEN`, `SEND_TOKEN`, `RECEIVE_TOKEN`. The Chain Tree structure is modeled as in Figure 3. This layout allows for efficient double-spend checking by sending in all the receives. However, a future improvement to the protocol will use balance check pointing and a cryptographic accumulator (or zk-snark) to prove non-existence of the receive.
 
 <img src="../assets/images/actor-dag.png">
-##### Figure 3 - Cryptocurrency branch of a Chain Tree
+##### Figure 3 - Token branch of a Chain Tree
 --
 
 ```
@@ -118,7 +118,7 @@ message MintTokenTransaction {
 }
 ```
 
-Any actor may mint their own tokens once they have been established within that chaintree via an `ESTABLISH_TOKEN` transaction. They do so by creating a MINT transaction on their Chain Tree. In order for a `MINT_TOKEN` transaction to be valid, the name of the currency must be prefaced by their Chain Tree’s DID. An example cryptocurrency might be named: `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700:cat_token` where `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700` is the DID and \'cat_token\' is the name of the currency. The only potential limitation a Chain Tree owner has on minting more of their own currency is the Monetary Policy set in place when the token was established.
+Any actor may mint their own tokens once they have been established within that chaintree via an `ESTABLISH_TOKEN` transaction. They do so by creating a MINT transaction on their Chain Tree. In order for a `MINT_TOKEN` transaction to be valid, the name of the token must be prefaced by their Chain Tree’s DID. An example token might be named: `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700:cat_token` where `did:tupelo:0xF964A90A0be7aC039E415aed6b2DD97651316700` is the DID and \'cat_token\' is the name of the token. The only potential limitation a Chain Tree owner has on minting more of their own token is the Monetary Policy set in place when the token was established.
 
 ```
 SEND_TOKEN


### PR DESCRIPTION
Update to replace all instances of "coin" with "token" & an implementation switch to the leaves data structure (from map to array).