### PR TITLE
Publishing latest and GREATEST perf numbers

### DIFF
--- a/platform_performance.md
+++ b/platform_performance.md
@@ -21,7 +21,21 @@ We will continue to share these numbers as they become available.
 
 ***
 
-## January 6th - Latest update
+## April 19th - Latest update
+Substantial performance improvements through consensus streamlining including
+optimizing subscriptions and improved bootstrapping.
+
+| Signers | Throughput  | Finality (mean)  | Finality (P95)  |
+| ------- |:-----------:|:---------:|:---------:|
+| 21      | 200 tx/sec   | 947 ms  | 2415 ms |
+| 100     | 200 tx/sec   | 831 ms  | 1739 ms |
+
+AWS Regions: 8  
+AWS Instance Types: c5.xlarge (4cpu 8gb ram)  
+
+***
+
+## January 6th
 The workflow was refactored to use actor model [ProtoActor](http://proto.actor).
 More of the state was moved to be held in-memory.
 


### PR DESCRIPTION
Updating the latest performance numbers so PoW can go out.
If we revise the 21 node (and I think we will) happy to make that change as soon as we have the updated numbers.