### PR TITLE
Fixing search.  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "jekyll", "~> 3.8.5"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
-gem "just-the-docs"
+gem "just-the-docs", "~> 0.2.7"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
-  just-the-docs
+  just-the-docs (~> 0.2.7)
   minima (~> 2.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ markdown: kramdown
 aux_links:
   "Main Tupelo Website":
     - "http://www.quorumcontrol.com"
-remote_theme: pmarsceill/just-the-docs
+# remote_theme: pmarsceill/just-the-docs
 theme: just-the-docs # this works locally but not when pushed
 plugins:
   - jekyll-feed

--- a/assets/js/search-data.json
+++ b/assets/js/search-data.json
@@ -1,0 +1,12 @@
+---
+---
+{
+  {% assign comma = false %}
+  {% for page in site.html_pages %}{% if page.search_exclude != true %}{% if comma == true%},{% endif %}"{{ forloop.index0 }}": {
+    "title": "{{ page.title | replace: '&amp;', '&' }}",
+    "content": "'+content+'",
+    "url": "{{ page.url | absolute_url }}",
+    "relUrl": "{{ page.url }}"
+  }{% assign comma = true %}
+  {% endif %}{% endfor %}
+}


### PR DESCRIPTION
Needed to escape some single quotes in /Users/andrew/gems/gems/just-the-docs-0.2.7/lib/tasks/search.rake
Which then generates search-data.json.
I am wondering if that also needs to be escaped actually... but its working locally so I would like to push it up and try it when github pages are serving it.