### PR TITLE
Switching all reference to tupelo.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-docs.quorumcontrol.com
+docs.tupelo.org

--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   Ledger) focused on modeling "things" be they real world or virtual.
   The team is focused on practical applications of blockchain technology
   and providing a platform which provide developers joy.
-# baseurl: "https://docs.quorumcontrol.com" # the subpath of your site, e.g. /blog
-url: "https://docs.quorumcontrol.com" # the base hostname & protocol for your site, e.g. http://example.com
+# baseurl: "https://docs.tupelo.org" # the subpath of your site, e.g. /blog
+url: "https://docs.tupelo.org" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: icarusz
 github_username:  icarusz
 
@@ -31,7 +31,7 @@ search_enabled: true
 markdown: kramdown
 aux_links:
   "Main Tupelo Website":
-    - "http://www.quorumcontrol.com"
+    - "http://www.tupelo.org"
 # remote_theme: pmarsceill/just-the-docs
 theme: just-the-docs # this works locally but not when pushed
 plugins:

--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -2,7 +2,7 @@
 
 <form action="https://getsimpleform.com/messages?form_api_token=e5c297254e437ec5b14c8207d9a15e08" method="post">
   <!-- the redirect_to is optional, the form will redirect to the referrer on submission -->
-  <input type='hidden' name='redirect_to' value='http://docs.quorumcontrol.com/thankyou.html' />
+  <input type='hidden' name='redirect_to' value='http://docs.tupelo.org/thankyou.html' />
   <!-- all your input fields here.... -->
   <h4 id="example" style="padding: .5em 4em .5em;">Name
   <!-- input type='text' name='Name' size="50" required style='color:blue;'/> -->

--- a/api_reference.md
+++ b/api_reference.md
@@ -21,7 +21,7 @@ next few months.
 ### WASM SDK - Tupelo DLT right from the browser
 
 #### [SOURCE](https://github.com/QuorumControl/tupelo-wasm-sdk)
-#### [GETTING STARTED GUIDE](https://www.quorumcontrol.com/blog/2019/8/22/new-wasm-based-sdk-for-tupelo)
+#### [GETTING STARTED GUIDE](https://www.tupelo.org/blog/2019/8/22/new-wasm-based-sdk-for-tupelo)
 
 ***
 

--- a/docs/chaintree.md
+++ b/docs/chaintree.md
@@ -37,7 +37,7 @@ end
 
 A ChainTree is [content addressable](https://en.wikipedia.org/wiki/Content-addressable_storage), meaning that a single hash of the root uniquely represents the entire data structure.
 
-[Tupelo's whitepaper](https://docs.quorumcontrol.com/docs/whitepaper.html) explains how ChainTrees use [IPLD](https://ipld.io/) internally.
+[Tupelo's whitepaper](https://docs.tupelo.org/docs/whitepaper.html) explains how ChainTrees use [IPLD](https://ipld.io/) internally.
 
 > [...] at a high level, IPLD specifies how to link data structures using a content addressable system (hashing). Conceptually similar to JSON, Tupelo uses CBOR (Compact Binary Object Representation) to model the data inside a ChainTree. CBOR specifies a canonical way to create a binary given key/value pairs. An object can link to another object by specifying a CID as a value within one if its key/value pairs. A CID represents a hash of the object linked TO. In this way, a single tip (hash of the root object) can be used to verify that all children of the object have not been tampered with.
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Need more information first?
 Read below to see how we’re different or get access to important documentation.
 {: .fs-5 .fw-300 }
 Want to jump right in and build?  Get started using your preferred web development framework and access
-Tupelo using the new **[Tupelo WASM SDK](https://www.quorumcontrol.com/blog/2019/8/22/new-wasm-based-sdk-for-tupelo) right from the browser.**
+Tupelo using the new **[Tupelo WASM SDK](https://www.tupelo.org/blog/2019/8/22/new-wasm-based-sdk-for-tupelo) right from the browser.**
 {: .fs-5 .fw-300 }
 
 # We Are Distributed Ledger Done Differently


### PR DESCRIPTION
Got some cross site CORS complaints on seaching so fixing up the URLs to all tupelo.org.