### PR TITLE
Getting mermaid happy again for graphs and diagrams in markdown.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,8 @@
         }
       });
     </script>
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.0.0/mermaid.min.js"></script>
   {% include analytics.html %}
 </head>

--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -1,9 +1,0 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.0.0/mermaid.min.js"></script>
-<script>
-var config = {
-    startOnLoad:true,
-    theme: 'neutral'
-};
-mermaid.initialize(config);
-window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
-</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,4 +95,16 @@ layout: table_wrappers
   </div>
 
 </body>
+<script>
+var config = {
+    startOnLoad:true,
+    theme: 'neutral',
+    flowchart:{
+            useMaxWidth:true,
+            htmlLabels:true
+        }
+};
+mermaid.initialize(config);
+window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
+</script>
 </html>

--- a/assets/css/just-the-docs.css
+++ b/assets/css/just-the-docs.css
@@ -1248,8 +1248,7 @@ thead th {
 code {
   padding: 0.2em 0.15em;
   font-weight: 400;
-  background-color: #f5f6fa;
-  border: 1px solid #eeebee;
+
   border-radius: 4px; }
 
 pre.highlight,

--- a/docs/chaintree.md
+++ b/docs/chaintree.md
@@ -13,7 +13,6 @@ A ChainTree is a new data structure that represents both digital and physical ob
 
 A ChainTree is a combination of a tree representing the current state, and a blockchain representing the previous states of an object. The blockchain part of a ChainTree is a linked list of blocks containing transactions. The tree is the current state of the ChainTree created by running the previous transactions. ChainTrees let you store arbitrary data in the leaf nodes of the tree using the  [IPLD standard](https://ipld.io/) .
 
-
 ```mermaid
 graph TD
 Root --> Tree


### PR DESCRIPTION
In addition to re-enabling, I figured out how to get rid of the annoying gray code boxes that were under each diagram and were making me nuts.  (Tweaked just-the-docs css.)